### PR TITLE
フラッシュメッセージを追加

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,14 +7,16 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to root_path
+      redirect_back_or_to root_path, success: t('.success') 
     else
-      render :new
+      flash.now[:error] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to login_path
+    flash[:success] = t('.success')
+    redirect_to login_path, status: :see_other
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path
+      redirect_to login_path, flash: { success: t('.success') }
     else
-      render :new
+      flash.now[:error] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,9 @@
   </head>
 
   <body>
-    <%= render "shared/header"%>
+    <%= render 'shared/header'%>
+    <%= render 'shared/flash_messages' %>
     <%= yield %>
-    <%= render "shared/footer"%>
+    <%= render 'shared/footer'%>
   </body>
 </html>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,17 @@
+<% flash.each do |type, msg| %>
+  <% if type == 'success' %>
+    <div class="alert alert-success shadow-lg">
+      <div>
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <span><%= msg %></span>
+      </div>
+    </div>
+  <% elsif type == 'error' %>
+    <div class="alert alert-error shadow-lg">
+      <div>
+        <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        <span><%= msg %></span>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
       <%= link_to 'みんなのオコゴトを見る', '#', class: 'btn btn-square btn-ghost whitespace-nowrap flex-auto' %>
       <%= link_to 'オコゴト画像を作成する', '#', class: 'btn btn-square btn-ghost whitespace-nowrap flex-1' %>
       <%= link_to 'マイページ', '#', class: 'btn btn-square btn-ghost whitespace-nowrap w-24' %>
-      <%= link_to t('defaults.logout'), logout_path, class: 'btn btn-square btn-ghost whitespace-nowrap w-24', data: { turbo_method: :delete } %>
+      <%= button_to t('defaults.logout'), logout_path, class: 'btn btn-square btn-ghost whitespace-nowrap w-24', method: :delete %>
     <% else %>
       <%= link_to t('defaults.login'), login_path, class: 'btn btn-square btn-ghost whitespace-nowrap w-24' %>
     <% end %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -8,8 +8,16 @@ ja:
       title: 'ユーザー登録'
       to_login_page: 'ログインページへ'
       submit: '登録する'
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   user_sessions:
     new:
       title: 'ログイン'
       to_register_page: '登録ページへ'
       password_forget: 'パスワードをお忘れの方はこちら'
+    create:
+      success: 'ログインしました'
+      fail: 'ログインに失敗しました'
+    destroy:
+      success: 'ログアウトしました'


### PR DESCRIPTION
## 概要
ユーザー登録とログイン時にフラッシュを追加

## コメント
- rails７ではstatusをつけないとflashが正確に表示されない場合があった。
- destroyアクションの時、link_toだと`status: :see_other`が必須だけど、button_toにすると必須ではないっぽい。（一応つけといた）
- ログアウトの時だけ、`success: t('.success')`だとうまくフラッシュが表示されなくて、別の行で`flash[:success] = t('.success')`と書き直したら表示されるようになった。