### PR TITLE
配色と遷移先を修正

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to root_path, success: t('.success')
+      redirect_back_or_to posts_path, success: t('.success')
     else
       flash.now[:error] = t('.fail')
       render :new, status: :unprocessable_entity

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,7 @@
       <p class="text-lg text-primary pt-2 ml-2"><%= @post.user.name %></br>（<%= @post.user.age_i18n %> , <%= @post.user.gender_i18n %>）</p>
       <% if current_user %>
         <details class="dropdown dropdown-end md:dropdown-right">
-          <summary tabindex="0" class="btn btn-ghost"><i class="fa-regular fa-circle-down text-slate-400"></i></summary>
+          <summary tabindex="0" class="btn btn-ghost"><i class="fa-regular fa-circle-down text-slate-500"></i></summary>
             <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-primary text-white rounded-box w-72 whitespace-nowrap">
               <li><%= link_to 'オコゴト画像をダウンロード', download_post_path(@post), data: { turbolinks: false }, method: :get %></li>
               <div class="tooltip tooltip-bottom tooltip-open tooltip-info" data-tip="sorry...頑張って準備中です!!">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     <% if logged_in? %>
       <details class="dropdown dropdown-end mr-2">
         <summary tabindex="0" class="btn btn-ghost m-1"><i class="fa-solid fa-bars fa-lg"></i></summary>
-        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-secondary whitespace-nowrap rounded-box w-60 hover:bg-">
+        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-secondary text-neutral whitespace-nowrap rounded-box w-60 hover:bg-">
           <li><%= link_to 'みんなのオコゴトを見る', posts_path %></li>
           <li><%= link_to 'オコゴト画像を作成する', new_okogoto_image_path %></li>
           <li><%= link_to 'マイページ', profile_path %></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-secondary text-white">
   <div class="flex-1">
-    <%= link_to image_tag('Okogoto_logo.png', size: '110'), root_path, class: 'ml-4' %>
+    <%= link_to image_tag('Okogoto_logo.png', size: '110'), posts_path, class: 'ml-4' %>
   </div>
   <div class="flex-none">
     <% if logged_in? %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,10 +9,10 @@ module.exports = {
     themes: [
       {
         mytheme: {
-          "primary": "#C1CBEE",
+          "primary": "#6495ED",
           "secondary": "#FFCF25",
           "accent": "#85B6FF",
-          "neutral": "#747474",
+          "neutral": "#78716c",
           "base-100": "#FFFFFF",
           "info": "#f5f5f4",
           "success": "#85B6FF",


### PR DESCRIPTION
## 概要
- 薄すぎて色が見にくかったので、もう少し濃くてみやすい色に変更
- ロゴクリック時とログイン後にLPページに遷移していたため、投稿一覧に遷移する

## コメント
色はたくさんの人に使ってもらうと思わなくて完全に自己満で選んでたけど、みんなが見やすい色を選ぶことも大切だってわかった。。。