### PR TITLE
モバイル、タブレットでは画像がめくれないようにする

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,7 @@
 <%= link_to post_path(post), class: 'lg:w-1/3 sm:w-1/2 w-full p-4' do %>
   <div class="flex relative w-full">
     <%= image_tag post.kogoto_image.url, class: 'absolute inset-0 w-full h-full object-cover object-center' %>
-    <div class="px-8 py-10 relative z-10 w-full border-4 border-primary bg-white opacity-0 hover:opacity-100">
+    <div class="px-8 py-10 relative z-10 w-full border-4 border-primary bg-white opacity-0 lg:hover:opacity-100">
       <h2 class="tracking-widest text-sm title-font font-medium text-primary mb-1"><%=post.user.name %></h2>
       <h1 class="title-font text-lg font-medium text-gray-400 mb-3"><%= l post.created_at, format: :short %></h1>
       <div class="chat chat-end">


### PR DESCRIPTION
## 概要
hover時の動作は1024px以上の端末のみ行うようにする
#90 