### PR TITLE
Fix:require: falseを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'kaminari'
 gem 'high_voltage', '~> 3.1'
 
 # サイトマップ
-gem 'aws-sdk-s3', require: false
+gem 'aws-sdk-s3'
 gem 'sitemap_generator'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]


### PR DESCRIPTION
## 概要

```
LoadError: Error: `Aws::S3::Resource` and/or `Aws::Credentials` are not defined.

Please `require 'aws-sdk'` - or another library that defines these classes.
```
が出たので、Gemfileのrequire: falseを外してみる
