### PR TITLE
ログイン前と後で遷移先を変える

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,13 @@
 <div class="navbar bg-secondary text-white">
-  <div class="flex-1">
-    <%= link_to image_tag('Okogoto_logo.png', size: '110'), posts_path, class: 'ml-4' %>
-  </div>
+  <% if logged_in? %>
+    <div class="flex-1">
+      <%= link_to image_tag('Okogoto_logo.png', size: '110'), posts_path, class: 'ml-4' %>
+    </div>
+  <% else %>
+    <div class="flex-1">
+      <%= link_to image_tag('Okogoto_logo.png', size: '110'), root_path, class: 'ml-4' %>
+    </div>
+  <% end %>
   <div class="flex-none">
     <% if logged_in? %>
       <details class="dropdown dropdown-end mr-2">


### PR DESCRIPTION
## 概要
ロゴをクリックしたとき、
ログイン前ならトップページ
ログイン後なら投稿一覧に遷移するように変更