### PR TITLE
投稿詳細ページに直前のページに戻るボタンを追加

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,11 +62,20 @@
     <% end %>
   </div>
 </div>
-<div class="flex justify-center">
-  <button class="btn btn btn-primary text-white mb-12">
-    <%= link_to :back do %>
+<% if request.referer&.include?('/posts') %>
+  <div class="flex justify-center">
+    <button class="btn btn btn-primary text-white mb-12">
+      <%= link_to :back do %>
+        <i class="fa-solid fa-chevron-left mr-1"></i>
+        <%= t('.back_before_page') %>
+      <% end %>
+    </button>
+  </div>
+<% else %>
+  <div class="flex justify-center">
+    <button class="btn btn btn-primary text-white mb-12">
       <i class="fa-solid fa-chevron-left mr-1"></i>
-      <%= t('.back_before_page') %>
-    <% end %>
-  </button>
-</div>
+      <%= link_to t('.back_before_page'), posts_path %>
+    </button>
+  </div>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,3 +62,11 @@
     <% end %>
   </div>
 </div>
+<div class="flex justify-center">
+  <button class="btn btn btn-primary text-white mb-12">
+    <%= link_to :back do %>
+      <i class="fa-solid fa-chevron-left mr-1"></i>
+      <%= t('.back_before_page') %>
+    <% end %>
+  </button>
+</div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -78,6 +78,7 @@ ja:
       edit: '投稿を編集する'
       delete: '投稿を削除する'
       delete_check: '投稿を削除しますか？'
+      back_before_page: 'みんなのオコゴトへもどる'
     destroy:
       success: '投稿を削除しました'
   okogoto_images:


### PR DESCRIPTION
## 概要
- 投稿の詳細ページに前のページへ戻るリンクを追加
- もしTwitterシェアからの遷移などで、前のリンクが投稿一覧ページでないときは、posts_pathに遷移するようにする

## コメント
自分が思いつく通りにとりあえず実装してみたけど
もっといい方法があるのかな〜〜〜〜〜〜？
でもこれがあれば一旦パンくずは要らなそうな感じ