### PR TITLE
マイページから投稿詳細に遷移したときは、マイページに戻るようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@
 /yarn-error.log
 
 /.env
+
+/.DS_Store
+/app/.DS_Store
+/app/javascript/.DS_Store

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,20 @@ module ApplicationHelper
       }
     }
   end
+
+  def back_before_page
+    if request.referer&.include?('/edit') || request.referer&.include?('/new')
+      link_to t('defaults.back_before_page'), posts_path
+    elsif request.referer&.include?('/posts')
+      link_to :back do
+        t('defaults.back_before_page')
+      end
+    elsif request.referer&.include?('/profile')
+      link_to :back do
+        t('defaults.back_before_mypage')
+      end
+    else
+      link_to t('defaults.back_before_page'), posts_path
+    end
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -71,6 +71,15 @@
       <% end %>
     </button>
   </div>
+<% elsif request.referer&.include?('/profile') %>
+  <div class="flex justify-center">
+    <button class="btn btn btn-primary text-white mb-12">
+      <%= link_to :back do %>
+        <i class="fa-solid fa-chevron-left mr-1"></i>
+        <%= t('.back_before_mypage') %>
+      <% end %>
+    </button>
+  </div>
 <% else %>
   <div class="flex justify-center">
     <button class="btn btn btn-primary text-white mb-12">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,29 +62,9 @@
     <% end %>
   </div>
 </div>
-<% if request.referer&.include?('/posts') %>
-  <div class="flex justify-center">
-    <button class="btn btn btn-primary text-white mb-12">
-      <%= link_to :back do %>
-        <i class="fa-solid fa-chevron-left mr-1"></i>
-        <%= t('.back_before_page') %>
-      <% end %>
-    </button>
-  </div>
-<% elsif request.referer&.include?('/profile') %>
-  <div class="flex justify-center">
-    <button class="btn btn btn-primary text-white mb-12">
-      <%= link_to :back do %>
-        <i class="fa-solid fa-chevron-left mr-1"></i>
-        <%= t('.back_before_mypage') %>
-      <% end %>
-    </button>
-  </div>
-<% else %>
-  <div class="flex justify-center">
-    <button class="btn btn btn-primary text-white mb-12">
-      <i class="fa-solid fa-chevron-left mr-1"></i>
-      <%= link_to t('.back_before_page'), posts_path %>
-    </button>
-  </div>
-<% end %>
+<div class="flex justify-center">
+  <button class="btn btn btn-primary text-white mb-12">
+    <i class="fa-solid fa-chevron-left mr-1"></i>
+    <%= back_before_page %>
+  </button>
+</div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -13,6 +13,9 @@ ja:
     not_authorized: '管理者権限がありません'
     delete: '削除'
     delete_check: '本当に削除していいですか？'
+    back_before_page: 'みんなのオコゴトへもどる'
+    back_before_mypage: 'マイページへもどる'
+
   time:
     formats:
       default: '%Y/%m/%d %H:%M:%S'
@@ -71,6 +74,7 @@ ja:
       created_image: '作成したオコゴト画像'
       back_page: '投稿の編集をやめる'
       post_edit: '投稿を更新する'
+      comment: '画像をみた感想やこのオコゴトを生んだあなたの経験を教えてください。'
     update:
       success: '投稿を更新しました！'
       fail: '投稿の更新に失敗しました'
@@ -78,8 +82,6 @@ ja:
       edit: '投稿を編集する'
       delete: '投稿を削除する'
       delete_check: '投稿を削除しますか？'
-      back_before_page: 'みんなのオコゴトへもどる'
-      back_before_mypage: 'マイページへもどる'
     destroy:
       success: '投稿を削除しました'
   okogoto_images:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -79,6 +79,7 @@ ja:
       delete: '投稿を削除する'
       delete_check: '投稿を削除しますか？'
       back_before_page: 'みんなのオコゴトへもどる'
+      back_before_mypage: 'マイページへもどる'
     destroy:
       success: '投稿を削除しました'
   okogoto_images:


### PR DESCRIPTION
## 概要
- マイページ⇨投稿詳細の時はマイページに戻るようにする
- 投稿作成、編集後に表示される詳細ページからは投稿一覧に遷移されるようにする

## コメント
viewがごちゃごちゃしたので、一旦helperに処理を移した（これは正しいのかよくワカラナイ・・・）
VScodeが重い、熱のせい？
ずっとコミットせずに放置してたファイルをgitignoreに追加