### PR TITLE
トップページのUIを改善

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -27,5 +27,10 @@
       <%= link_to_prev_page @posts, t('defaults.previous'), class: 'inline-flex items-center px-4 py-2 mr-3 text-sm font-medium text-primary bg-white border border-primary rounded-lg hover:bg-gray-100 hover:text-primary dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white' %>
       <%= link_to_next_page @posts, t('defaults.next'), class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-primary bg-white border border-primary rounded-lg hover:bg-gray-100 hover:text-primary dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white'%>
     </div>
+    <% if !logged_in? %>
+      <div class="flex justify-center mt-12">
+        <%= link_to t('.to_create_user'), new_user_path, class: 'btn btn-primary btn-lg rounded-full text-white' %>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -1,16 +1,16 @@
 <% set_meta_tags( title: 'Okogotoへようこそ！' ) %>
 <section class="bg-base-100">
-  <div class="container mx-auto flex px-5 py-24 flex-col items-center">
-    <div class="lg:w-2/6 md:w-3/6 w-5/6 mb-10 object-cover object-center">
-      <%= image_tag 'okogoto_explanation.png', size: '720x600' %>
+  <div class="container mx-auto flex px-5 pb-24 pt-12 flex-col items-center">
+    <div class="md:w-2/3 w-full mb-10 object-cover object-center">
+      <%= image_tag 'okogoto_explanation.png' %>
     </div>
     <div class="text-center lg:w-2/3 w-full">
-      <h1 class="title-font sm:text-2xl text-xl mb-4 font-medium text-primary text-center">Okogotoでは
+      <h1 class="title-font sm:text-3xl text-xl mb-10 font-medium text-primary text-center">Okogotoでは
         <br class="lg:inline-block">背景やフォントを使って
         <br class="lg:inline-block">あなたの言葉の雰囲気を変え
         <br class="lg:inline-block">客観的に見ることをお手伝いします
       </h1>
-      <div class=" collapse bg-info mt-6 rounded-3xl">
+      <div class="collapse bg-info mt-6 rounded-3xl">
         <input type="checkbox" /> 
         <div class="collapse-title text-lg font-medium text-primary">
           <i class="fa-solid fa-play text-primary mx-1"></i>
@@ -32,26 +32,20 @@
           </p>
         </div>
       </div>
+      <div class="flex justify-center mt-10">
+        <%= link_to t('.to_create_user'), new_user_path, class: 'btn btn-secondary btn-lg rounded-full text-white' %>
+      </div>
       <div class="flex justify-center mt-8 mb-16">
-        <%= link_to t('.to_posts_index'), posts_path, class: 'btn btn-secondary rounded-full text-white' %>
+        <%= link_to t('.to_posts_index'), posts_path, class: 'btn btn-primary rounded-full text-white' %>
       </div>
-      <h1 class="title-font sm:text-2xl text-xl my-4 font-medium text-neutral">オコゴト画像のつくりかた</h1>
-      <div class="chat chat-start md:ml-44 xl:ml-64">
-        <div class="chat-bubble chat-bubble-primary whitespace-nowrap w-80 text-white">1. オコゴトを入力</div>
-      </div>
-      <div class="chat chat-start md:ml-44 xl:ml-64">
-        <div class="chat-bubble chat-bubble-primary whitespace-nowrap w-80 text-white">2. 見てみたい雰囲気の画像を選択</div>
-      </div>
-      <div class="chat chat-start md:ml-44 xl:ml-64">
-        <div class="chat-bubble chat-bubble-primary whitespace-nowrap w-80 text-white">3. オコゴト画像に説明を追加</div>
-      </div>
-      <div class="chat chat-start md:ml-36 xl:ml-56">
-        <div class="chat-bubble chat-bubble-primary whitespace-nowrap w-96 text-white">
-          <i class="fa-regular fa-circle-check mr-1"></i>
-          投稿された画像はダウンロード可能です！
-        </div>
-      </div>
-      </div>
+      <h1 class="title-font sm:text-2xl text-xl my-4 font-medium text-neutral mt-28"><i class="fa-regular fa-font-awesome fa-xl mr-2"></i>オコゴト画像のつくりかた</h1>
+      <p class="text-primary text-mono text-xl my-2"><i class="fa-solid fa-1 fa-sm mr-2"></i> オコゴトを入力</p>
+      <p class="text-primary text-mono text-xl my-2"><i class="fa-solid fa-2 fa-sm mr-2"></i> 見てみたい雰囲気の画像を選択</>
+      <p class="text-primary text-mono text-xl my-2"><i class="fa-solid fa-3 fa-sm mr-2"></i> オコゴト画像に説明を追加</div>
+      <p class="underline underline-offset-8 decoration-dashed text-primary text-mono md:text-xl text-md mt-10">
+        <i class="fa-regular fa-circle-check fa-lg mr-1"></i>
+        投稿された画像はダウンロード可能です！
+      </p>
       <div class="mockup-phone border-secondary mt-6">
         <div class="camera"></div> 
         <div class="display">
@@ -60,25 +54,22 @@
           </div>
         </div>
       </div>
-      <div class="chat chat-start mt-2 mb-4">
-        <div class="chat-bubble chat-bubble-primary whitespace-nowrap w-64 text-white">
-          スマホver壁紙は</br>
-          7月のカレンダーです
-        </div>
-      </div>
+      <p class="text-primary text-mono text-center text-xl mt-5 mb-12">
+        スマホver壁紙は7月のカレンダーです
+      </p>
       <div class="mockup-window border border-secondary md:w-1/2 mt-4">
         <div class="flex justify-center border-t border-secondary">
           <%= image_tag 'desctop_example.png', class: 'object-cover' %>
         </div>
       </div>
-      <div class="chat chat-start mt-2 mb-4">
-        <div class="chat-bubble chat-bubble-primary whitespace-nowrap w-64 text-white">
-          ダウンロードした画像は</br>
-          パソコンの壁紙にもできます
-        </div>
-      </div>
+      <p class="text-primary text-mono text-center text-xl mt-5 mb-12">
+        ダウンロードした画像はパソコンの壁紙にもできます
+      </p>
       <div class="flex justify-center mt-8">
-        <%= link_to t('.to_create_user'), new_user_path, class: 'btn btn-secondary rounded-full text-white' %>
+        <%= link_to t('.to_create_user'), new_user_path, class: 'btn btn-secondary btn-lg rounded-full text-white' %>
+      </div>
+      <div class="flex justify-center my-8">
+        <%= link_to t('.to_posts_index'), posts_path, class: 'btn btn-primary rounded-full text-white' %>
       </div>
     </div>
   </div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -24,7 +24,7 @@ ja:
   top_pages:
     top:
       to_posts_index: 'みんなのオコゴトを見てみる'
-      to_create_user: '登録してオコゴトを投稿する'
+      to_create_user: '登録してオコゴト画像をつくってみる'
   users:
     new: 
       title: 'ユーザー登録'
@@ -60,6 +60,7 @@ ja:
       title: 'みんなのオコゴト'
       no_result: '最初のオコゴトを投稿してみませんか？'
       search_tag: 'どんな状況のオコゴトを見てみますか？'
+      to_create_user: '登録してオコゴト画像をつくってみる'
     new:
       created_image: '作成したオコゴト画像'
       delete_post: '画像作成からやり直す'


### PR DESCRIPTION
## 概要
- 黒塗りにするのはボタンだけにして、どれがクリックできるのか、直感的にわかるようにする
- 新規登録へ動線を増やす
  - ボタンを大きく
  - ログインしてない時はオコゴト一覧ページにも新規登録ページへの遷移を表示する 

## コメント
一覧ページへのアクセス数に対して、ログイン、新規登録ページへのアクセスが少なすぎる
↓
新規登録しやすくなるような動線、ボタンの拡大表示