### PR TITLE
一覧ページと詳細ページのレイアウトをモバイル版でよりみやすく修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <%= link_to post_path(post), class: 'lg:w-1/3 sm:w-1/2 w-full p-4' do %>
   <div class="flex relative w-full">
-    <%= image_tag post.kogoto_image.url, class: 'absolute inset-0 w-full h-full object-cover object-center outline-dashed outline-gray-200' %>
+    <%= image_tag post.kogoto_image.url, class: 'absolute inset-0 w-full h-full object-cover object-center md:outline-dashed md:outline-gray-200' %>
     <div class="px-8 py-10 relative z-10 w-full border-4 border-primary bg-white opacity-0 lg:hover:opacity-100">
       <h2 class="tracking-widest text-sm title-font font-medium text-primary mb-1"><%= post.user.name %></h2>
       <h1 class="title-font text-lg font-medium text-gray-400 mb-3"><%= l post.created_at, format: :short %></h1>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
                         url: "https://okogoto.net/posts/#{@post.id}" },
                   twitter: { card: 'summary_large_image' }) %>
 <div class="flex justify-center">
-  <div class="card w-96 bg-base-100 shadow-xl my-12 outline-dashed outline-gray-300">
+  <div class="card md:w-96 w-5/6 bg-base-100 shadow-xl my-12 outline-dashed outline-gray-300">
     <div class="flex justify-around mt-4">
       <p class="text-lg text-primary pt-2 ml-2"><%= @post.user.name %></br>（<%= @post.user.age_i18n %> , <%= @post.user.gender_i18n %>）</p>
       <% if current_user %>
@@ -17,7 +17,7 @@
         </details>
       <% end %>
     </div>
-    <figure class="px-10 py-4">
+    <figure class="md:px-10 py-4">
       <%= image_tag @post.kogoto_image_url %>
     </figure>
     <div class="text-right text-primary pr-10"><%= l @post.created_at, format: :short %></div>


### PR DESCRIPTION
## 概要
- スマホから見た時、一覧ページの枠線がうるさい感じがしたのでmd以上だけで表示されるように変更
- 詳細ページがスマホの枠とかぶって不格好だったので、枠が画面内に収まるように修正

## コメント
初めてvimで編集してコミットまでしてみたけど、意外とすんなりできたし
思ってたほど難しくないかも。
というか、使い慣れたらこれめちゃくちゃ良いかも。。。